### PR TITLE
Update URL structure to be /api/<x> instead of just /<x>

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,14 +40,13 @@ def get_items():
     return flask.jsonify(data_dict)
 
 """
-@app.route("/boards/<id>", methods=["DELETE"])
+@app.route("/api/boards/<id>", methods=["DELETE"])
 def delete_board(id):
     data_dict = {} 
     cursor = conn.cursor() 
 
     try:
-        cursor.execute("DELETE FROM board WHERE id=%s", (id))
-        
+        cursor.execute("DELETE FROM board WHERE id=%s", (id))      
         
         data_dict["statusCode"] = 202 
         data_dict["status"] = f"Deleted board {id}"

--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ def delete_board(id):
 
     try:
         cursor.execute("DELETE FROM board WHERE id=%s", (id))      
-        
+       
         data_dict["statusCode"] = 202 
         data_dict["status"] = f"Deleted board {id}"
     except Exception as e:


### PR DESCRIPTION
Hey guys - one small change here. I realized I forgot to use the `api` prefix for our endpoints. This is a common industry practice that lets you avoid collisions. An example is that if we have the api url for boards be `/api/boards` that means the frontend can use the more human-readable url `/boards` without collisions. Let me know if that doesn't make sense or if you have questions. 